### PR TITLE
Error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn compute_availability( station_charger_map: HashMap<u32, HashSet<u32>>,
         let mut station_reported_time: Vec<TimeRange> = Vec::new();
         for charger in chargers {
             let charger_times = charger_uptime_map.get(charger);
-            if charger_times == None {
+            if charger_times.is_none() {
                 continue;
             }
             for charger_time in charger_times.unwrap() {


### PR DESCRIPTION
Makes every function return a `Result`. 
Instead of a function ending process, it returns an error, that propagates all the way to main() function, where it's printed to `stderr`.


Closes #15 
Closes #17 
Closes #15 